### PR TITLE
Initial check-in.  All tested and working as expected in my local dev…

### DIFF
--- a/generate.database/VersionUpdates/11.0/StoredProcedures/Create/Staging.Rollover_SourceSystemReferenceData.StoredProcedure.sql
+++ b/generate.database/VersionUpdates/11.0/StoredProcedures/Create/Staging.Rollover_SourceSystemReferenceData.StoredProcedure.sql
@@ -1,17 +1,84 @@
 ﻿CREATE PROCEDURE [Staging].[Rollover_SourceSystemReferenceData]
+	@FromYear int = NULL,
+	@ToYear int = NULL
 AS
 BEGIN
 
-	declare @StagingSchoolYear int, @MaxSchoolYearInSSRD int = 0
+	/******************************************************************************************
+	@FromYear and @ToYear can be provided when running this procedure manually to do a rollover
+	If @FromYear is NULL and @ToYear is NULL (default when called from Wrappers), then
+	use SchoolYear from Staging.StateDetail to determine if rollover is needed
+	********************************************************************************************/
 
-	-- Build a temp table of all School Years that exist in Staging.StateDetail (typically there will only be one year)
-	-- This assures that SourceSystemReferenceData has records that correspond to the staging school year.
-	IF OBJECT_ID(N'tempdb..#SchoolYearsInStaging') IS NOT NULL DROP TABLE #SchoolYearsInStaging
-	select distinct SchoolYear into #SchoolYearsInStaging from Staging.StateDetail 
+	if @FromYear is not null and @ToYear is not null
+		begin
+			-- Validations -----------------------------
+			-- 1 Verify SSRD has data for @FromYear
+			if (select count(*) from Staging.SourceSystemReferenceData where SchoolYear = @FromYear) = 0
+				begin
+					insert into app.DataMigrationHistories (DataMigrationHistoryDate, DataMigrationTypeId, DataMigrationHistoryMessage) 
+					values (getutcdate(), 4, 'ERROR: Manual rollover of SourceSystemReferenceData failed because no records exist in Staging.SourceSystemReferenceData for ' + convert(varchar, @FromYear) + '.') 
+					return
+				end
+
+			-- 2 Verify SSRD does not already have data for @ToYear
+			if (select count(*) from Staging.SourceSystemReferenceData where SchoolYear = @ToYear) <> 0
+				begin
+					insert into app.DataMigrationHistories (DataMigrationHistoryDate, DataMigrationTypeId, DataMigrationHistoryMessage) 
+					values (getutcdate(), 4, 'ERROR: Manual rollover of SourceSystemReferenceData failed because records already exist in Staging.SourceSystemReferenceData for ' + convert(varchar, @ToYear) + '.') 
+					return
+				end
+
+				INSERT INTO staging.SourceSystemReferenceData (
+					SchoolYear
+					,TableName
+					,TableFilter
+					,InputCode
+					,OutputCode
+				)
+				SELECT DISTINCT
+					@ToYear
+					,TableName
+					,TableFilter
+					,InputCode
+					,OutputCode
+				FROM staging.SourceSystemReferenceData
+				WHERE SchoolYear = @FromYear
+
+				insert into app.DataMigrationHistories (DataMigrationHistoryDate, DataMigrationTypeId, DataMigrationHistoryMessage) 
+				values (getutcdate(), 4, 'SourceSystemReferenceData manually rolled over for ' + convert(varchar, @ToYear) + ' from ' + convert(varchar, @FromYear)) 
+			return
+		end
+	
+	declare @StagingSchoolYear int
+
+	-- Validations -----------------------------
+	-- 1 Verify SSRD has data
+	if (select count(*) from Staging.SourceSystemReferenceData) = 0
+		begin
+			insert into app.DataMigrationHistories (DataMigrationHistoryDate, DataMigrationTypeId, DataMigrationHistoryMessage) 
+			values (getutcdate(), 4, 'ERROR: Rollover of SourceSystemReferenceData failed because no records exist in Staging.SourceSystemReferenceData.') 
+			return
+		end
+
+	-- 2 Verify StateDetail has at least one record
+	if (select count(*) from Staging.StateDetail) = 0
+		begin
+			insert into app.DataMigrationHistories (DataMigrationHistoryDate, DataMigrationTypeId, DataMigrationHistoryMessage) 
+			values (getutcdate(), 4, 'ERROR: Rollover of SourceSystemReferenceData failed because no records exist in Staging.StateDetail') 
+			return
+		end
+	else
+		begin
+			-- Build a temp table of all School Years that exist in Staging.StateDetail (typically there will only be one year)
+			-- This assures that SourceSystemReferenceData has records that correspond to the staging school year.
+			IF OBJECT_ID(N'tempdb..#SchoolYearsInStaging') IS NOT NULL DROP TABLE #SchoolYearsInStaging
+			select distinct SchoolYear into #SchoolYearsInStaging from Staging.StateDetail where SchoolYear is not null
+		end
+
 	while exists(select top 1 * from #SchoolYearsInStaging)
 		begin
-			select @MaxSchoolYearInSSRD = (select max(SchoolYear) from Staging.SourceSystemReferenceData)
-			select @StagingSchoolYear = (select top 1 SchoolYear from #SchoolYearsInStaging)
+			select @StagingSchoolYear = (select top 1 SchoolYear from #SchoolYearsInStaging order by SchoolYear) -- get oldest school year first to sequentially loop through years and rollover SSRD as needed
 
 				-- Roll the staging.SourceSystemReferenceData OptionSets into the next school year
 				-- if there are no records in SourceSystemReferenceData for the Staging School Year
@@ -21,12 +88,9 @@ BEGIN
 						-- Verify there are records from the previous year to roll forward
 						if (select count(*) from Staging.SourceSystemReferenceData where SchoolYear = @StagingSchoolYear-1) = 0
 							begin
-								if @MaxSchoolYearInSSRD = 0
-									begin
-										insert into app.DataMigrationHistories (DataMigrationHistoryDate, DataMigrationTypeId, DataMigrationHistoryMessage) 
-										values (getutcdate(), 4, 'ERROR: Rollover of SourceSystemReferenceData Failed for ' + convert(varchar, @StagingSchoolYear) + ' because no records exist for any previous years.') 
-										return
-									end
+								insert into app.DataMigrationHistories (DataMigrationHistoryDate, DataMigrationTypeId, DataMigrationHistoryMessage) 
+								values (getutcdate(), 4, 'ERROR: Rollover of SourceSystemReferenceData failed for ' + convert(varchar, @StagingSchoolYear) + ' because no records exist in Staging.SourceSystemReferenceData for ' + convert(varchar, @StagingSchoolYear-1) + '.') 
+								return
 							end
 
 						INSERT INTO staging.SourceSystemReferenceData (
@@ -43,20 +107,15 @@ BEGIN
 							,InputCode
 							,OutputCode
 						FROM staging.SourceSystemReferenceData
-						WHERE SchoolYear = @MaxSchoolYearInSSRD
-					END
-				delete from #SchoolYearsInStaging where SchoolYear = @StagingSchoolYear
+						WHERE SchoolYear = @StagingSchoolYear-1
+		
 
-				if @MaxSchoolYearInSSRD = @StagingSchoolYear - 1
-					begin
 						insert into app.DataMigrationHistories (DataMigrationHistoryDate, DataMigrationTypeId, DataMigrationHistoryMessage) 
-						values (getutcdate(), 4, 'SourceSystemReferenceData rolled over for ' + convert(varchar, @StagingSchoolYear) + ' from ' + convert(varchar, @MaxSchoolYearInSSRD)) 
-					end
-				else
-					begin
-						insert into app.DataMigrationHistories (DataMigrationHistoryDate, DataMigrationTypeId, DataMigrationHistoryMessage) 
-						values (getutcdate(), 4, 'NOTE: SourceSystemReferenceData rolled over for ' + convert(varchar, @StagingSchoolYear) + ' from ' + convert(varchar, @MaxSchoolYearInSSRD) + ' because no data existed for ' + convert(varchar, @StagingSchoolYear-1) ) 
-					end	
+						values (getutcdate(), 4, 'SourceSystemReferenceData rolled over for ' + convert(varchar, @StagingSchoolYear) + ' from ' + convert(varchar, @StagingSchoolYear-1)) 
+					END
+
+			delete from #SchoolYearsInStaging where SchoolYear = @StagingSchoolYear
+
 		end -- end of loop
 
 END

--- a/generate.database/VersionUpdates/11.1_prerelease/VersionScripts.csv
+++ b/generate.database/VersionUpdates/11.1_prerelease/VersionScripts.csv
@@ -20,4 +20,6 @@ StoredProcedures\\Drop,Staging.Staging-to-FactK12StudentAssessments.StoredProced
 StoredProcedures\\Create,Staging.Staging-to-FactK12StudentAssessments.StoredProcedure.sql,0
 StoredProcedures\\Drop,App.Wrapper_Migrate_Assessments_to_RDS.StoredProcedure.sql,0
 StoredProcedures\\Create,App.Wrapper_Migrate_Assessments_to_RDS.StoredProcedure.sql,0
+StoredProcedures\\Drop,Staging.Rollover_SourceSystemReferenceData.StoredProcedure.sql,0
+StoredProcedures\\Create,Staging.Rollover_SourceSystemReferenceData.StoredProcedure.sql,0
 VersionUpdates\\11.1_prerelease,UpdateDbVersion.sql,0


### PR DESCRIPTION
… environment

NOTE: I added the ability to run this rollover procedure manually by passing in a from and to year.  If those are null, then the procedure uses the StateDetail school year as normal during migrations.  This is noted in the comments in the procedure.