### PR TITLE
Ready to Review

### DIFF
--- a/generate.database/VersionUpdates/11.3_prerelease/AddUniqueConstraintonStagingK12PersonRace.sql
+++ b/generate.database/VersionUpdates/11.3_prerelease/AddUniqueConstraintonStagingK12PersonRace.sql
@@ -1,0 +1,21 @@
+/****************************************************
+CIID-5808
+January 15, 2024
+If K12PersonRace contains duplicate records for Student, LEA, School, Race and SchoolYear, 
+the view RDS.vwUnduplicatedRaceMap would treat this as "Multiple Races".  To prevent this,
+create a Unique Constraint on table Staging.K12PersonRace to not allow duplicate
+records into the table from the ETL.
+*****************************************************/
+
+if exists(
+	SELECT * 
+    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_NAME='UC_K12PersonRace'
+	)
+	begin
+		ALTER TABLE staging.K12PersonRace DROP CONSTRAINT [UC_K12PersonRace]
+	end	
+
+alter table staging.K12PersonRace
+add constraint UC_K12PersonRace 
+UNIQUE (StudentIdentifierState, LEAIdentifierSeaAccountability, SchoolIdentifierSea, RaceType, SchoolYear)

--- a/generate.database/VersionUpdates/11.3_prerelease/VersionScripts.csv
+++ b/generate.database/VersionUpdates/11.3_prerelease/VersionScripts.csv
@@ -4,6 +4,7 @@ VersionUpdates\\11.3_prerelease,UpdateEdFactsMigrantCodes.sql,0
 VersionUpdates\\11.3_prerelease,Metadata-Updates.sql,0
 VersionUpdates\\11.3_prerelease,Metadata-2023-Updates.sql,0
 VersionUpdates\\11.3_prerelease,Metadata-2024-Updates.sql,0
+VersionUpdates\\11.3_prerelease,AddUniqueConstraintonStagingK12PersonRace.sql,0
 Views\\Drop,RDS.vwDimMigrantStatuses.View.sql
 Views\\Create,RDS.vwDimMigrantStatuses.View.sql
 Views\\Drop,RDS.vwDimMilitaryStatuses.View.sql


### PR DESCRIPTION
While testing CIID-5808, I discovered that if a student has more than one record in Staging.K12PersonRace for the same LEA, School, Race and SchoolYear, the view vwUnduplicatedRaceMap was treating this as "Multiple Races".  For example, if the student had two identical records in K12PersonRace with race of WHITE, the result in the Fact and Report tables was "Multiple Races".

Adding a Unique Constraint to this table will prevent duplicate records in K12PersonRace.