### PR TITLE
Update RDS.Get_CountSQL to explicitly handle the TOT category in 088 …

### DIFF
--- a/generate.web/DatabaseScripts/Functions/Create/RDS.Get_CountSQL.UserDefinedFunction.sql
+++ b/generate.web/DatabaseScripts/Functions/Create/RDS.Get_CountSQL.UserDefinedFunction.sql
@@ -7037,7 +7037,7 @@ BEGIN
 
 				if @categorySetCode = 'TOT'
 				begin
-					if(@reportCode in ('002','089','052','033')) 
+					if(@reportCode in ('002','089','052','033','088','143')) 
 					begin	
  
 						set @sql = @sql + '


### PR DESCRIPTION
…and 144. This change should update the logic to use the #categorySet table as the basis for the INSERT query instead of RDS.DimLeas.